### PR TITLE
Refactor react-native-client-sdk

### DIFF
--- a/examples/video-chat/hooks/useJoinRoom.ts
+++ b/examples/video-chat/hooks/useJoinRoom.ts
@@ -1,6 +1,5 @@
 import {
   useCamera,
-  joinRoom as fjJoinRoom,
   useMicrophone,
   VideoQuality,
 } from '@fishjam-dev/react-native-client';
@@ -67,21 +66,11 @@ export function useJoinRoom({
       cameraEnabled: isCameraAvailable,
     });
 
-    await fjJoinRoom({
-      name: 'RN mobile',
-    });
-
     await startMicrophone({
       audioTrackMetadata: { active: isMicrophoneAvailable, type: 'audio' },
       microphoneEnabled: isMicrophoneAvailable,
     });
-  }, [
-    isCameraAvailable,
-    isMicrophoneAvailable,
-    fjJoinRoom,
-    startCamera,
-    startMicrophone,
-  ]);
+  }, [isCameraAvailable, isMicrophoneAvailable, startCamera, startMicrophone]);
 
   return { joinRoom };
 }

--- a/examples/video-chat/ios/Podfile.lock
+++ b/examples/video-chat/ios/Podfile.lock
@@ -1144,7 +1144,8 @@ DEPENDENCIES:
   - ExpoModulesCore (from `../../../node_modules/expo-modules-core`)
   - FBLazyVector (from `../../../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../../node_modules/react-native/React/FBReactNativeSpec`)
-  - FishjamClient/Broadcast
+  - FishjamClient (from `https://github.com/fishjam-dev/ios-client-sdk.git`, commit `9d22ecaf75cc563a24212c13e15cd83a3f76ac0f`)
+  - FishjamClient/Broadcast (from `https://github.com/fishjam-dev/ios-client-sdk.git`, commit `9d22ecaf75cc563a24212c13e15cd83a3f76ac0f`)
   - glog (from `../../../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../../../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
@@ -1238,6 +1239,9 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/Libraries/FBLazyVector"
   FBReactNativeSpec:
     :path: "../../../node_modules/react-native/React/FBReactNativeSpec"
+  FishjamClient:
+    :commit: 9d22ecaf75cc563a24212c13e15cd83a3f76ac0f
+    :git: https://github.com/fishjam-dev/ios-client-sdk.git
   glog:
     :podspec: "../../../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
@@ -1340,6 +1344,11 @@ EXTERNAL SOURCES:
   Yoga:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
+CHECKOUT OPTIONS:
+  FishjamClient:
+    :commit: 9d22ecaf75cc563a24212c13e15cd83a3f76ac0f
+    :git: https://github.com/fishjam-dev/ios-client-sdk.git
+
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
@@ -1353,7 +1362,7 @@ SPEC CHECKSUMS:
   ExpoModulesCore: 4a8928a228569301ac4fc4a1e846713e05754d05
   FBLazyVector: 84f6edbe225f38aebd9deaf1540a4160b1f087d7
   FBReactNativeSpec: 75c20d8ec82467d86fc15e5cb41c7501258a884f
-  FishjamClient: b811a3384a56839bed9553ad0fee1cd4b3422d3d
+  FishjamClient: c1cf10484a705500c9fac352b75a4c1b8cec3cf2
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: b2669ce35fc4ac14f523b307aff8896799829fe2
@@ -1418,4 +1427,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 0376e85da25bcfda7c0095d7c9d174ee924ff49d
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/examples/video-chat/screens/ConnectWithRoomManagerScreen.tsx
+++ b/examples/video-chat/screens/ConnectWithRoomManagerScreen.tsx
@@ -71,7 +71,7 @@ const ConnectScreen = ({ navigation }: Props) => {
         userName,
       );
 
-      await connect(fishjamUrl, token);
+      await connect(fishjamUrl, token, { name: 'RN mobile' });
 
       navigation.navigate('Preview', { userName });
     } catch (e) {

--- a/examples/video-chat/screens/ConnectWithTokenScreen.tsx
+++ b/examples/video-chat/screens/ConnectWithTokenScreen.tsx
@@ -44,7 +44,7 @@ const ConnectScreen = ({ navigation }: Props) => {
   const onTapConnectButton = async () => {
     try {
       setConnectionError(null);
-      await connect(fishjamUrl.trim(), peerToken.trim());
+      await connect(fishjamUrl.trim(), peerToken.trim(), { name: 'RN mobile' });
       navigation.navigate('Preview');
     } catch (e) {
       const message =

--- a/examples/video-chat/screens/RoomScreen.tsx
+++ b/examples/video-chat/screens/RoomScreen.tsx
@@ -1,5 +1,5 @@
 import {
-  cleanUp,
+  leaveRoom,
   usePeers,
   useScreencast,
   ScreencastQuality,
@@ -70,7 +70,7 @@ const RoomScreen = ({ navigation, route }: Props) => {
   const { toggleScreencast, isScreencastOn } = useScreencast();
 
   const onDisconnectPress = useCallback(() => {
-    cleanUp();
+    leaveRoom();
     navigation.navigate('Home');
   }, [navigation]);
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "workspaces": {
     "packages": [
       "packages/react-native-client",
+      "packages/react-native-client/debug",
       "examples/video-chat",
       "examples/webdriverio-test"
     ]

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
@@ -99,38 +99,25 @@ class RNFishjamClientModule : Module() {
     }
 
     OnActivityDestroys {
-      rnFishjamClient.cleanUp()
+      rnFishjamClient.leaveRoom()
     }
 
     OnActivityResult { _, result ->
       rnFishjamClient.onActivityResult(result.requestCode, result.resultCode, result.data)
     }
 
-    AsyncFunction("connect") { url: String, peerToken: String, promise: Promise ->
+    AsyncFunction("connect") { url: String, peerToken: String, peerMetadata: Map<String, Any>, promise: Promise ->
       CoroutineScope(Dispatchers.Main).launch {
         rnFishjamClient.create()
-        rnFishjamClient.connect(url, peerToken, promise)
+        rnFishjamClient.connect(url, peerToken, peerMetadata, promise)
       }
     }
 
-    AsyncFunction("joinRoom") { peerMetadata: Map<String, Any>, promise: Promise ->
-      CoroutineScope(Dispatchers.Main).launch {
-        rnFishjamClient.joinRoom(peerMetadata, promise)
-      }
-    }
-
-    AsyncFunction("leaveRoom") { ->
-      CoroutineScope(Dispatchers.Main).launch {
+    AsyncFunction("leaveRoom") Coroutine { ->
+      withContext(Dispatchers.Main) {
         rnFishjamClient.leaveRoom()
       }
     }
-
-    AsyncFunction("cleanUp") Coroutine { ->
-      withContext(Dispatchers.Main) {
-        rnFishjamClient.cleanUp()
-      }
-    }
-
 
     AsyncFunction("startCamera") Coroutine { config: CameraConfig ->
       withContext(Dispatchers.Main) {

--- a/packages/react-native-client/debug/index.ts
+++ b/packages/react-native-client/debug/index.ts
@@ -1,0 +1,15 @@
+import RNFishjamClientModule from '../src/RNFishjamClientModule';
+import { LoggingSeverity } from './types';
+
+export { useRTCStatistics } from './useRTCStatistics';
+
+/**
+ * Function that changes level of debugging logs in WebRTC.
+ * @param severity to use when displaying logs
+ * @returns a promise that is resolved when debug severity is changed
+ */
+export function changeWebRTCLoggingSeverity(
+  severity: LoggingSeverity,
+): Promise<void> {
+  return RNFishjamClientModule.changeWebRTCLoggingSeverity(severity);
+}

--- a/packages/react-native-client/debug/package.json
+++ b/packages/react-native-client/debug/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../build/debug/index.js",
+  "types": "../build/debug/index.d.ts"
+}

--- a/packages/react-native-client/debug/types.ts
+++ b/packages/react-native-client/debug/types.ts
@@ -1,0 +1,64 @@
+export enum LoggingSeverity {
+  Verbose = 'verbose',
+  Info = 'info',
+  Warning = 'warning',
+  Error = 'error',
+  None = 'none',
+}
+
+/**
+ * A record of the total time, in seconds,
+ * that this stream has spent in each quality limitation state.
+ * none: The resolution and/or framerate is not limited.
+ * bandwidth: The resolution and/or framerate is primarily limited due to
+ * congestion cues during bandwidth estimation.
+ * Typical, congestion control algorithms use inter-arrival time,
+ * round-trip time, packet or other congestion cues to perform bandwidth estimation.
+ * cpu: The resolution and/or framerate is primarily limited due to CPU load.
+ * other: The resolution and/or framerate is primarily limited
+ * for a reason other than the above.
+ */
+export type QualityLimitationDurations = {
+  bandwidth: number;
+  cpu: number;
+  none: number;
+  other: number;
+};
+
+export type RTCOutboundStats = {
+  'kind': string;
+  'rid': string;
+  'bytesSent': number;
+  'targetBitrate': number;
+  'packetsSent': number;
+  'framesEncoded': number;
+  'framesPerSecond': number;
+  'frameWidth': number;
+  'frameHeight': number;
+  'qualityLimitationDurations': QualityLimitationDurations;
+  'bytesSent/s': number;
+  'packetsSent/s': number;
+  'framesEncoded/s': number;
+};
+
+export type RTCInboundStats = {
+  'kind': number;
+  'jitter': number;
+  'packetsLost': number;
+  'packetsReceived': number;
+  'bytesReceived': number;
+  'framesReceived': number;
+  'frameWidth': number;
+  'frameHeight': number;
+  'framesPerSecond': number;
+  'framesDropped': number;
+  'packetsLost/s': number;
+  'packetsReceived/s': number;
+  'bytesReceived/s': number;
+  'framesReceived/s': number;
+  'framesDropped/s': number;
+};
+
+export type RTCTrackStats = RTCOutboundStats | RTCInboundStats;
+
+export type RTCStats = { [key: string]: RTCTrackStats };

--- a/packages/react-native-client/debug/useRTCStatistics.ts
+++ b/packages/react-native-client/debug/useRTCStatistics.ts
@@ -1,12 +1,8 @@
 import { takeRight } from 'lodash';
 import { useCallback, useEffect, useState } from 'react';
 
-import {
-  RTCInboundStats,
-  RTCOutboundStats,
-  RTCStats,
-} from '../RNFishjamClient.types';
-import RNFishjamClientModule from '../RNFishjamClientModule';
+import RNFishjamClientModule from '../src/RNFishjamClientModule';
+import { RTCInboundStats, RTCOutboundStats, RTCStats } from './types';
 
 /**
  * This hook provides access to current rtc statistics data.

--- a/packages/react-native-client/ios/RNFishjamClientModule.swift
+++ b/packages/react-native-client/ios/RNFishjamClientModule.swift
@@ -74,21 +74,13 @@ public class RNFishjamClientModule: Module {
             self.sendEvent(eventName, data)
         }
 
-        AsyncFunction("connect") { (url: String, peerToken: String, promise: Promise) in
+        AsyncFunction("connect") { (url: String, peerToken: String, peerMetadata: [String: Any], promise: Promise) in
             try rnFishjamClient.create()
-            rnFishjamClient.connect(url: url, peerToken: peerToken, promise: promise)
-        }
-
-        AsyncFunction("joinRoom") { (peerMetadata: [String: Any], promise: Promise) in
-            rnFishjamClient.joinRoom(peerMetadata: peerMetadata, promise: promise)
+            rnFishjamClient.connect(url: url, peerToken: peerToken, peerMetadata: peerMetadata, promise: promise)
         }
 
         AsyncFunction("leaveRoom") {
             rnFishjamClient.leaveRoom()
-        }
-
-        AsyncFunction("cleanUp") {
-            rnFishjamClient.cleanUp()
         }
 
         AsyncFunction("startCamera") { (config: CameraConfig) in

--- a/packages/react-native-client/src/RNFishjamClient.types.ts
+++ b/packages/react-native-client/src/RNFishjamClient.types.ts
@@ -246,71 +246,6 @@ export type CaptureDevice = {
   isBackFacing: boolean;
 };
 
-export enum LoggingSeverity {
-  Verbose = 'verbose',
-  Info = 'info',
-  Warning = 'warning',
-  Error = 'error',
-  None = 'none',
-}
-
-/**
- * A record of the total time, in seconds,
- * that this stream has spent in each quality limitation state.
- * none: The resolution and/or framerate is not limited.
- * bandwidth: The resolution and/or framerate is primarily limited due to
- * congestion cues during bandwidth estimation.
- * Typical, congestion control algorithms use inter-arrival time,
- * round-trip time, packet or other congestion cues to perform bandwidth estimation.
- * cpu: The resolution and/or framerate is primarily limited due to CPU load.
- * other: The resolution and/or framerate is primarily limited
- * for a reason other than the above.
- */
-export type QualityLimitationDurations = {
-  bandwidth: number;
-  cpu: number;
-  none: number;
-  other: number;
-};
-
-export type RTCOutboundStats = {
-  'kind': string;
-  'rid': string;
-  'bytesSent': number;
-  'targetBitrate': number;
-  'packetsSent': number;
-  'framesEncoded': number;
-  'framesPerSecond': number;
-  'frameWidth': number;
-  'frameHeight': number;
-  'qualityLimitationDurations': QualityLimitationDurations;
-  'bytesSent/s': number;
-  'packetsSent/s': number;
-  'framesEncoded/s': number;
-};
-
-export type RTCInboundStats = {
-  'kind': number;
-  'jitter': number;
-  'packetsLost': number;
-  'packetsReceived': number;
-  'bytesReceived': number;
-  'framesReceived': number;
-  'frameWidth': number;
-  'frameHeight': number;
-  'framesPerSecond': number;
-  'framesDropped': number;
-  'packetsLost/s': number;
-  'packetsReceived/s': number;
-  'bytesReceived/s': number;
-  'framesReceived/s': number;
-  'framesDropped/s': number;
-};
-
-export type RTCTrackStats = RTCOutboundStats | RTCInboundStats;
-
-export type RTCStats = { [key: string]: RTCTrackStats };
-
 export type EndpointsUpdateEvent<
   MetadataType extends Metadata,
   VideoTrackMetadataType extends Metadata,
@@ -376,10 +311,12 @@ export type VideoRendererProps = {
 
 export type RNFishjamClient = {
   appContext?: any;
-  connect: (url: string, peerToken: string) => Promise<void>;
-  joinRoom: (peerMetadata: Metadata) => Promise<void>;
+  connect: (
+    url: string,
+    peerToken: string,
+    peerMetadata: Metadata,
+  ) => Promise<void>;
   leaveRoom: () => Promise<void>;
-  cleanUp: () => Promise<void>;
   startCamera: <MetadataType extends Metadata>(
     config: Partial<CameraConfig<MetadataType>>,
   ) => Promise<void>;
@@ -438,6 +375,4 @@ export type RNFishjamClient = {
     bandwidth: number,
   ) => Promise<void>;
   setVideoTrackBandwidth: (bandwidth: number) => Promise<void>;
-  changeWebRTCLoggingSeverity: (severity: string) => Promise<void>;
-  getStatistics: () => Promise<RTCStats>;
 };

--- a/packages/react-native-client/src/RNFishjamClientModule.ts
+++ b/packages/react-native-client/src/RNFishjamClientModule.ts
@@ -4,9 +4,17 @@ import { NativeModule } from 'react-native';
 import { RNFishjamClient } from './RNFishjamClient.types';
 import { NativeMembraneMock } from './__mocks__/native';
 import { isJest } from './utils';
+import type { RTCStats } from '../debug/types';
 
 const nativeModule = isJest()
   ? NativeMembraneMock
   : requireNativeModule('RNFishjamClient');
 
-export default nativeModule as RNFishjamClient & NativeModule;
+type FishjamDebugFunctions = {
+  changeWebRTCLoggingSeverity: (severity: string) => Promise<void>;
+  getStatistics: () => Promise<RTCStats>;
+};
+
+export default nativeModule as RNFishjamClient &
+  FishjamDebugFunctions &
+  NativeModule;

--- a/packages/react-native-client/src/common/client.ts
+++ b/packages/react-native-client/src/common/client.ts
@@ -1,18 +1,14 @@
 import { Metadata } from '../RNFishjamClient.types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
 
-export const connect = (url: string, peerToken: string) => {
-  return RNFishjamClientModule.connect(url, peerToken);
-};
-
-export const joinRoom = (peerMetadata: Metadata) => {
-  return RNFishjamClientModule.joinRoom(peerMetadata);
+export const connect = (
+  url: string,
+  peerToken: string,
+  peerMetadata: Metadata,
+) => {
+  return RNFishjamClientModule.connect(url, peerToken, peerMetadata);
 };
 
 export const leaveRoom = () => {
   return RNFishjamClientModule.leaveRoom();
-};
-
-export const cleanUp = () => {
-  return RNFishjamClientModule.cleanUp();
 };

--- a/packages/react-native-client/src/common/webRTC.ts
+++ b/packages/react-native-client/src/common/webRTC.ts
@@ -1,4 +1,4 @@
-import { LoggingSeverity, TrackEncoding } from '../RNFishjamClient.types';
+import { TrackEncoding } from '../RNFishjamClient.types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
 
 /**
@@ -15,15 +15,4 @@ export async function setTargetTrackEncoding(
   encoding: TrackEncoding,
 ) {
   await RNFishjamClientModule.setTargetTrackEncoding(trackId, encoding);
-}
-
-/**
- * Function that changes level of debugging logs in WebRTC.
- * @param severity to use when displaying logs
- * @returns a promise that is resolved when debug severity is changed
- */
-export function changeWebRTCLoggingSeverity(
-  severity: LoggingSeverity,
-): Promise<void> {
-  return RNFishjamClientModule.changeWebRTCLoggingSeverity(severity);
 }

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -5,9 +5,7 @@ import { useEndpoints } from './hooks/useEndpoints';
 export { useAudioSettings } from './hooks/useAudioSettings';
 export { useBandwidthEstimation } from './hooks/useBandwidthEstimation';
 export { useCamera } from './hooks/useCamera';
-export { useEndpoints } from './hooks/useEndpoints';
 export { useMicrophone } from './hooks/useMicrophone';
-export { useRTCStatistics } from './hooks/useRTCStatistics';
 export { useScreencast } from './hooks/useScreencast';
 
 export {
@@ -15,10 +13,7 @@ export {
   updateEndpointMetadata,
   updateVideoTrackMetadata,
 } from './common/metadata';
-export {
-  changeWebRTCLoggingSeverity,
-  setTargetTrackEncoding,
-} from './common/webRTC';
+export { setTargetTrackEncoding } from './common/webRTC';
 export * from './common/client';
 
 export { default as VideoPreviewView } from './VideoPreviewView';

--- a/packages/react-native-client/tsconfig.json
+++ b/packages/react-native-client/tsconfig.json
@@ -4,6 +4,6 @@
   "compilerOptions": {
     "outDir": "./build"
   },
-  "include": ["./src"],
+  "include": ["./src", "./debug"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7759,6 +7759,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug-8d5cae@workspace:packages/react-native-client/debug":
+  version: 0.0.0-use.local
+  resolution: "debug-8d5cae@workspace:packages/react-native-client/debug"
+  languageName: unknown
+  linkType: soft
+
 "debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"


### PR DESCRIPTION
- merge connect and joinRoom functions
- merge leaveRoom and cleanUp functions
- move debug functions to /debug namespace
- remove endpoints from public api (I left it in internal code, we'll think about them once we add components into mobile sdk)